### PR TITLE
Environment precondition checks

### DIFF
--- a/Sources/App/Extensions/Application+Static.swift
+++ b/Sources/App/Extensions/Application+Static.swift
@@ -8,13 +8,14 @@
 import Vapor
 
 extension Application {
-
-    static let baseUrl = Environment.get("BASE_URL")!
-    static let databaseUrl = URL(string: Environment.get("DB_URL")!)!
+    
+    static let baseUrl: String = Environment.fetch("BASE_URL")
+    
+    static let databaseUrl: URL = URL(string: Environment.fetch("DB_URL"))!
     
     // paths are always absolute, with a trailing slash
     struct Paths {
-        static let base: String = Environment.get("BASE_PATH")!
+        static let base: String = Environment.fetch("BASE_PATH")
         static let `public`: String = Paths.base + "Public/"
         static let assets: String = Paths.public + "assets/"
         static let resources: String = Paths.base + "Resources/"

--- a/Sources/App/Extensions/Environment+FetchValue.swift
+++ b/Sources/App/Extensions/Environment+FetchValue.swift
@@ -1,0 +1,21 @@
+//
+//  Environmetn+FetchValue.swift
+//  
+//
+//  Created by Michael Critz on 8/9/20.
+//
+
+import Vapor
+
+extension Environment {
+    static func fetch(_ key: String) -> String {
+        let fetchedValue: String? = Environment.get(key)
+        guard let realValue = fetchedValue else {
+            precondition(false, """
+                \(key) is not defined in the Environment.
+                Check README.md or documentation for how to set environment variables.
+                """)
+        }
+        return realValue
+    }
+}

--- a/Tests/AppTests/EnvironmentTests.swift
+++ b/Tests/AppTests/EnvironmentTests.swift
@@ -1,0 +1,23 @@
+//
+//  EnvironmentTests.swift
+//  
+//
+//  Created by Michael Critz on 8/9/20.
+//
+
+import XCTVapor
+@testable import App
+
+final class EnvironmentTests: XCTestCase {
+
+    static var allTests = [
+        ("testFetchEnvironmentValue", testFetchEnvironmentValue),
+    ]
+    
+    func testFetchEnvironmentValue() throws {
+        let key = "HOME"
+        let value = Environment.get(key)
+        XCTAssertEqual(value, Environment.fetch(key))
+    }
+}
+


### PR DESCRIPTION
@tib Added `precondition(_: message:)` checks. This should give new developers a bit of a clue how to properly configure a Feather installation rather than failing a force-unwrap.