### PR TITLE
Adding extensions for expanding tilde in path and getting absolute path

### DIFF
--- a/Sources/App/Extensions/Application+Static.swift
+++ b/Sources/App/Extensions/Application+Static.swift
@@ -15,7 +15,7 @@ extension Application {
     
     // paths are always absolute, with a trailing slash
     struct Paths {
-        static let base: String = Environment.fetch("BASE_PATH").expandingTildeInPath
+        static let base: String = Environment.path("BASE_PATH")
         static let `public`: String = Paths.base + "Public/"
         static let assets: String = Paths.public + "assets/"
         static let resources: String = Paths.base + "Resources/"

--- a/Sources/App/Extensions/Application+Static.swift
+++ b/Sources/App/Extensions/Application+Static.swift
@@ -15,7 +15,7 @@ extension Application {
     
     // paths are always absolute, with a trailing slash
     struct Paths {
-        static let base: String = Environment.fetch("BASE_PATH")
+        static let base: String = Environment.fetch("BASE_PATH").expandingTildeInPath
         static let `public`: String = Paths.base + "Public/"
         static let assets: String = Paths.public + "assets/"
         static let resources: String = Paths.base + "Resources/"

--- a/Sources/App/Extensions/Environment+FetchValue.swift
+++ b/Sources/App/Extensions/Environment+FetchValue.swift
@@ -18,4 +18,12 @@ extension Environment {
         }
         return realValue
     }
+    
+    static func path(_ key: String) -> String {
+        let rawPath = fetch(key)
+        let resolved = rawPath.expandingTildeInPath
+        let path = resolved.withTrailingSlash
+        
+        return path
+    }
 }

--- a/Sources/App/Extensions/String+AbsolutePath.swift
+++ b/Sources/App/Extensions/String+AbsolutePath.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Julian Gentges on 10.08.20.
+//
+
+import Foundation
+
+extension String {
+    public var absolutePath: String {
+        if self.hasSuffix("/") {
+            return self
+        }
+        
+        return self + "/"
+    }
+}

--- a/Sources/App/Extensions/String+ExpandingTilde.swift
+++ b/Sources/App/Extensions/String+ExpandingTilde.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by Julian Gentges on 10.08.20.
+//
+
+import Foundation
+
+extension String {
+    public var expandingTildeInPath: String {
+        var path = NSString(string: self).expandingTildeInPath
+        
+        if self.hasSuffix("/") {
+            path += "/"
+        }
+        return path
+    }
+}

--- a/Sources/App/Extensions/String+ExpandingTilde.swift
+++ b/Sources/App/Extensions/String+ExpandingTilde.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension String {
-    public var expandingTildeInPath: String {
+    var expandingTildeInPath: String {
         var path = NSString(string: self).expandingTildeInPath
         
         if self.hasSuffix("/") {

--- a/Sources/App/Extensions/String+TrailingSlash.swift
+++ b/Sources/App/Extensions/String+TrailingSlash.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension String {
-    public var absolutePath: String {
+    public var withTrailingSlash: String {
         if self.hasSuffix("/") {
             return self
         }

--- a/Sources/App/Extensions/String+TrailingSlash.swift
+++ b/Sources/App/Extensions/String+TrailingSlash.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension String {
-    public var withTrailingSlash: String {
+    var withTrailingSlash: String {
         if self.hasSuffix("/") {
             return self
         }


### PR DESCRIPTION
Base on the issue #7 and the recommendation of @tib I created two extensions to `String`:
- `expandingTildeInPath`
- `absolutePath`

I then used the two extensions in `Application+Static` to resolve the path from the environment and prevent errors.
By using `expandingTildeInPath` the `~` in the path is replaced with the users directory, preventing weird behaviour of the filesystem.
Additionally `absolutePath` makes sure that the path has a trailing slash. Otherwise new folders would be created one level beneath the wanted folder.