### PR TITLE
Addresses Swift 5.3 trailing closure warning

### DIFF
--- a/Tests/AppTests/UserTests.swift
+++ b/Tests/AppTests/UserTests.swift
@@ -25,14 +25,15 @@ final class UserTests: XCTestCase {
         defer { app.shutdown() }
         try configure(app)
 
-        try app.test(.GET, "/login/") { res in
+        try app.test(.GET, "/login/",
+                     afterResponse:  { res in
             guard let contentType = res.content.contentType else {
                 XCTFail("Content must have a contentType")
                 return
             }
             XCTAssertEqual(contentType, htmlMediaType)
             XCTAssertEqual(res.status, .ok)
-        }
+        })
     }
     
     fileprivate func login(_ req: inout XCTHTTPRequest, username: String, password: String) throws {


### PR DESCRIPTION
silences one of those annoying ⚠️ when using Xcode 12 / Swift 5.3