### PR TITLE
Settings to allow discovery of Client browser Language.

### DIFF
--- a/Sources/App/Modules/Site/Bundle/Templates/Admin/Settings.html
+++ b/Sources/App/Modules/Site/Bundle/Templates/Admin/Settings.html
@@ -32,9 +32,11 @@
             <fieldset class="p m:bottom:l br:xs">
                 <legend class="p:horizontal:s">#($system.localization ?? "Localization")</legend>
                 
-                #(field = ["id": "locale", "label": $system.locale ?? "Locale", "required": true, "data": fields.locale])
+                #(field = ["id": "clientlocale", "label": $system.settings.clientlocale ?? "Discover client browser Locale", "required": false, "data": fields.clientlocale])
                 #inline("Admin/Fields/Selection")
-                
+
+                #(field = ["id": "locale", "label": $system.locale ?? "Default Locale", "required": true, "data": fields.locale])
+                #inline("Admin/Fields/Selection")
                 
                 #(field = ["id": "timezone", "label": $system.timezone ?? "Timezone", "required": true, "data": fields.timezone])
                 #inline("Admin/Fields/Selection")

--- a/Sources/App/Modules/Site/Bundle/Templates/Admin/Settings.html
+++ b/Sources/App/Modules/Site/Bundle/Templates/Admin/Settings.html
@@ -1,5 +1,5 @@
 #define(toolbarCenter):
-    Site settings
+    #($system.settings.title ?? "Site settings")
 #enddefine
 #define(body):
 <div id="site-settings" class="wrapper w">
@@ -13,12 +13,12 @@
             </fieldset>
 
             <fieldset class="p m:bottom:l br:xs">
-                <legend class="p:horizontal:s">General</legend>
+                <legend class="p:horizontal:s">#($system.general ?? "General")</legend>
                 
                 #(field = ["id": "formToken", "value": formToken])
                 #inline("Admin/Fields/Hidden")
 
-                #(field = ["id": "image", "label": "Logo", "class": "small", "data": fields.image, "accept": "image/png"])
+                #(field = ["id": "image", "label": $system.logo ?? "Logo", "class": "small", "data": fields.image, "accept": "image/png"])
                 #inline("Admin/Fields/File")
 
                 #(field = ["id": "title", "required": true, "data": fields.title])
@@ -30,62 +30,63 @@
             </fieldset>
 
             <fieldset class="p m:bottom:l br:xs">
-                <legend class="p:horizontal:s">Localization</legend>
+                <legend class="p:horizontal:s">#($system.localization ?? "Localization")</legend>
                 
-                #(field = ["id": "locale", "label": "Locale", "required": true, "data": fields.locale])
+                #(field = ["id": "locale", "label": $system.locale ?? "Locale", "required": true, "data": fields.locale])
                 #inline("Admin/Fields/Selection")
                 
-                #(field = ["id": "timezone", "required": true, "data": fields.timezone])
+                
+                #(field = ["id": "timezone", "label": $system.timezone ?? "Timezone", "required": true, "data": fields.timezone])
                 #inline("Admin/Fields/Selection")
             
             </fieldset>
 
             <fieldset class="p m:bottom:l br:xs">
-                <legend class="p:horizontal:s">Design</legend>
+                <legend class="p:horizontal:s">#($system.design ?? "Design")</legend>
 
-                #(field = ["id": "primaryColor", "label": "Primary link color", "more": "e.g #cafe00", "data": fields.primaryColor])
+                #(field = ["id": "primaryColor", "label": $system.settings.primary.link.color ?? "Primary link color", "more": "e.g #cafe00", "data": fields.primaryColor])
                 #inline("Admin/Fields/Text")
                 
-                #(field = ["id": "secondaryColor", "label": "Secondary link color", "more": "e.g #cafe00", "data": fields.secondaryColor])
+                #(field = ["id": "secondaryColor", "label": $system.settings.secondary.link.color ?? "Secondary link color", "more": "e.g #cafe00", "data": fields.secondaryColor])
                 #inline("Admin/Fields/Text")
                 
-                #(field = ["id": "fontFamily", "label": "Font family", "more": "e.g sans-serif", "data": fields.fontFamily])
+                #(field = ["id": "fontFamily", "label": $system.settings.font.family ?? "Font family", "more": "e.g sans-serif", "data": fields.fontFamily])
                 #inline("Admin/Fields/Text")
                 
-                #(field = ["id": "fontSize", "label": "Base font size", "more": "e.g 16px", "data": fields.fontSize])
+                #(field = ["id": "fontSize", "label":  $system.settings.font.base.size ?? "Base font size", "more": "e.g 16px", "data": fields.fontSize])
                 #inline("Admin/Fields/Text")
 
             </fieldset>
 
             <fieldset class="p m:bottom:l br:xs">
-                <legend class="p:horizontal:s">Code injection</legend>
+                <legend class="p:horizontal:s">#($system.code.injection ?? "Code injection")</legend>
                 
-                #(field = ["id": "css", "size": "small", "data": fields.css])
+                #(field = ["id": "css", "label": $system.settings.css ?? "CSS", "size": "small", "data": fields.css])
                 #inline("Admin/Fields/Textarea")
                 
-                #(field = ["id": "js", "size": "small", "data": fields.js])
+                #(field = ["id": "js", "label": $system.settings.js ?? "JavaScript", "size": "small", "data": fields.js])
                 #inline("Admin/Fields/Textarea")
             
             </fieldset>
 
             <fieldset class="p m:bottom:l br:xs">
-                <legend class="p:horizontal:s">Footer</legend>
+                <legend class="p:horizontal:s">#($system.footer ?? "Footer")</legend>
                 
-                #(field = ["id": "footer", "label": "Top area", "size": "small", "data": fields.footer])
+                #(field = ["id": "footer", "label": $system.top.area ?? "Top area", "size": "small", "data": fields.footer])
                 #inline("Admin/Fields/Textarea")
                 
-                #(field = ["id": "footerBottom", "label": "Bottom area", "size": "small", "data": fields.footerBottom])
+                #(field = ["id": "footerBottom", "label": $system.bottom.area ?? "Bottom area", "size": "small", "data": fields.footerBottom])
                 #inline("Admin/Fields/Textarea")
                 
-                #(field = ["id": "copy", "label": "Copyright", "size": "small", "required": true, "data": fields.copy])
+                #(field = ["id": "copy", "label": $system.copyright ?? "Copyright", "size": "small", "required": true, "data": fields.copy])
                 #inline("Admin/Fields/Textarea")
                 
-                #(field = ["id": "copyYearStart", "label": "Copyright start year", "data": fields.copyYearStart])
+                #(field = ["id": "copyYearStart", "label":  $system.copyright.start ?? "Copyright start year", "data": fields.copyYearStart])
                 #inline("Admin/Fields/Text")
             
             </fieldset>
 
-            #(field = ["label": "Save"])
+            #(field = ["label": $system.save ?? "Save"])
             #inline("Admin/Fields/Button")
         </form>
     </div>

--- a/Sources/App/Modules/Site/Controllers/SiteAdminController.swift
+++ b/Sources/App/Modules/Site/Controllers/SiteAdminController.swift
@@ -22,6 +22,7 @@ final class SiteAdminController {
         form.fontFamily.value = req.variables.get("site.font.family") ?? ""
         form.fontSize.value = req.variables.get("site.font.size") ?? ""
         form.locale.value = Application.Config.locale.identifier
+        form.clientlocale.value = Application.Config.clientlocale ? "true" : "false"
         form.timezone.value = Application.Config.timezone.identifier
         form.css.value = req.variables.get("site.css") ?? ""
         form.js.value = req.variables.get("site.js") ?? ""
@@ -75,6 +76,7 @@ final class SiteAdminController {
             }
 
             Application.Config.set("site.locale", value: form.locale.value)
+            Application.Config.set("site.clientlocale", value: form.clientlocale.value)
             Application.Config.set("site.timezone", value: form.timezone.value)
 
             return req.eventLoop.flatten([

--- a/Sources/App/Modules/Site/Forms/SiteSettingsForm.swift
+++ b/Sources/App/Modules/Site/Forms/SiteSettingsForm.swift
@@ -17,6 +17,7 @@ final class SiteSettingsForm: Form {
         var fontFamily: String
         var fontSize: String
         var locale: String
+        var clientlocale: String
         var timezone: String
         var css: String
         var js: String
@@ -35,6 +36,7 @@ final class SiteSettingsForm: Form {
     var fontFamily = StringFormField()
     var fontSize = StringFormField()
     var locale = StringSelectionFormField()
+    var clientlocale = StringSelectionFormField()
     var timezone = StringSelectionFormField()
     var css = StringFormField()
     var js = StringFormField()
@@ -54,6 +56,7 @@ final class SiteSettingsForm: Form {
             "fontFamily": fontFamily,
             "fontSize": fontSize,
             "locale": locale,
+            "clientlocale": clientlocale,
             "timezone": timezone,
             "css": css,
             "js": js,
@@ -81,6 +84,7 @@ final class SiteSettingsForm: Form {
         fontFamily.value = context.fontFamily
         fontSize.value = context.fontSize
         locale.value = context.locale
+        clientlocale.value = context.clientlocale
         timezone.value = context.timezone
         css.value = context.css
         js.value = context.js
@@ -97,6 +101,10 @@ final class SiteSettingsForm: Form {
 
     func initialize() {
         locale.options = FormFieldStringOption.locales
+        clientlocale.options = [
+            FormFieldStringOption.init(key: "false", label: "Ignore browser settings"),
+            FormFieldStringOption.init(key: "true", label: "Use client browser settings"),
+        ]
         timezone.options = FormFieldStringOption.gmtTimezones
     }
 


### PR DESCRIPTION
Hello,

please review this PR on feather-core first:
[feather-core PR1](https://github.com/BinaryBirds/feather-core/pull/1)

This PR is to add the setting in the admin console, to let feather-core discover the client locale and return the appropriate string.

I also update the Settings.html file to use system variable so we can configure the text (& translation in the variables)

Thanks,

Denis

