### PR TITLE
Add account app module and server wiring

### DIFF
--- a/backend/Package.swift
+++ b/backend/Package.swift
@@ -111,6 +111,7 @@ let package = Package(
         .package(path: "./app-modules/app-user-module"),
         .package(path: "./app-modules/app-auth-module"),
         .package(path: "./app-modules/app-media-module"),
+        .package(path: "./app-modules/app-account-module"),
     ],
     targets: [
         .target(
@@ -143,6 +144,7 @@ let package = Package(
                 .product(name: "AuthApplication", package: "app-auth-module"),
                 .product(name: "AuthInfrastructure", package: "app-auth-module"),
                 .product(name: "MediaInfrastructure", package: "app-media-module"),
+                .product(name: "AccountInfrastructure", package: "app-account-module"),
 
                 .target(name: "Environment"),
             ],
@@ -171,6 +173,7 @@ let package = Package(
                 .product(name: "UserInfrastructure", package: "app-user-module"),
                 .product(name: "AuthInfrastructure", package: "app-auth-module"),
                 .product(name: "MediaInfrastructure", package: "app-media-module"),
+                .product(name: "AccountInfrastructure", package: "app-account-module"),
 
                 .target(name: "Environment"),
             ],
@@ -211,6 +214,8 @@ let package = Package(
                 .product(name: "UserInfrastructure", package: "app-user-module"),
                 .product(name: "AuthInfrastructure", package: "app-auth-module"),
                 .product(name: "MediaInfrastructure", package: "app-media-module"),
+                .product(name: "AccountApplication", package: "app-account-module"),
+                .product(name: "AccountInfrastructure", package: "app-account-module"),
 
                 .target(name: "Environment"),
             ],

--- a/backend/Sources/Server/Modules/AppModules.swift
+++ b/backend/Sources/Server/Modules/AppModules.swift
@@ -14,6 +14,8 @@ import RedirectApplication
 import RedirectInfrastructure
 import BlogApplication
 import BlogInfrastructure
+import AccountApplication
+import AccountInfrastructure
 
 struct AppModules: Sendable {
 
@@ -28,6 +30,7 @@ struct AppModules: Sendable {
     let user: UserModule
     let auth: AuthModule
     let media: MediaModule
+    let account: AccountModule
 
     init(
         infrastructure: AppInfrastructure
@@ -78,6 +81,10 @@ struct AppModules: Sendable {
             authorizer: authorizer
         )
         self.media = .init(
+            infrastructure: infrastructure,
+            authorizer: authorizer
+        )
+        self.account = .init(
             infrastructure: infrastructure,
             authorizer: authorizer
         )

--- a/backend/Sources/Server/Modules/Builders/AccountModule.swift
+++ b/backend/Sources/Server/Modules/Builders/AccountModule.swift
@@ -1,0 +1,18 @@
+import AccountApplication
+import AccountInfrastructure
+import Application
+import Infrastructure
+
+struct AccountModule: Sendable {
+
+    private let infrastructure: AppInfrastructure
+    private let authorizer: any Authorizer
+
+    init(
+        infrastructure: AppInfrastructure,
+        authorizer: any Authorizer
+    ) {
+        self.infrastructure = infrastructure
+        self.authorizer = authorizer
+    }
+}

--- a/backend/app-modules/app-account-module/Makefile
+++ b/backend/app-modules/app-account-module/Makefile
@@ -1,0 +1,58 @@
+SHELL=/bin/bash
+
+baseUrl = https://raw.githubusercontent.com/BinaryBirds/github-workflows/main/scripts
+certVolume ?= app_account_module_certificates
+certOutputDir ?= .docker/certs
+certOutputFile ?= $(certOutputDir)/ca.pem
+
+check: symlinks language deps lint headers docc-warnings package
+
+package:
+	curl -fsSL $(baseUrl)/check-swift-package.sh | bash
+
+breakage:
+	curl -fsSL $(baseUrl)/check-api-breakage.sh | bash
+
+symlinks:
+	curl -fsSL $(baseUrl)/check-broken-symlinks.sh | bash
+
+language:
+	curl -fsSL $(baseUrl)/check-unacceptable-language.sh | bash
+
+deps:
+	curl -fsSL $(baseUrl)/check-local-swift-dependencies.sh | bash
+
+lint:
+	curl -fsSL $(baseUrl)/run-swift-format.sh | bash
+
+format:
+	curl -fsSL $(baseUrl)/run-swift-format.sh | bash -s -- --fix
+
+docc-local:
+	curl -fsSL $(baseUrl)/generate-docc.sh | bash -s -- --local
+
+run-docc:
+	curl -fsSL $(baseUrl)/run-docc-docker.sh | bash
+
+docc-warnings:
+	curl -fsSL $(baseUrl)/check-docc-warnings.sh | bash
+
+headers:
+	curl -fsSL $(baseUrl)/check-swift-headers.sh | bash
+
+fix-headers:
+	curl -fsSL $(baseUrl)/check-swift-headers.sh | bash -s -- --fix
+
+test:
+	swift test --parallel
+
+docker-test:
+	docker build -t app-account-module-tests . -f ./docker/tests/Dockerfile && docker run --rm app-account-module-tests
+
+export-postgres-ca:
+	mkdir -p $(certOutputDir)
+	docker run --rm \
+		-v $(certVolume):/from \
+		-v $(PWD)/$(certOutputDir):/to \
+		alpine sh -c 'cp /from/ca.pem /to/ca.pem'
+	@echo "Exported CA certificate to: $(certOutputFile)"

--- a/backend/app-modules/app-account-module/Package.resolved
+++ b/backend/app-modules/app-account-module/Package.resolved
@@ -1,0 +1,168 @@
+{
+  "originHash" : "9c1cf17e7dedf36fe7fdcd4eba5f8271a7450a4375378a4b6cd89d7a93559f97",
+  "pins" : [
+    {
+      "identity" : "feather-database",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/feather-framework/feather-database",
+      "state" : {
+        "revision" : "55b08d7bd028c7eddbd231efaaaa0d38e78c0b9b",
+        "version" : "1.0.0-beta.5"
+      }
+    },
+    {
+      "identity" : "feather-database-postgres",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/feather-framework/feather-database-postgres",
+      "state" : {
+        "revision" : "331615d7a0e9fed84d501194aa210dcca00f5922",
+        "version" : "1.0.0-beta.6"
+      }
+    },
+    {
+      "identity" : "feather-mail",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/feather-framework/feather-mail",
+      "state" : {
+        "revision" : "71aa4867f61c4f9f8b86cba2980f6e5e44cc0bed",
+        "version" : "1.0.0-beta.3"
+      }
+    },
+    {
+      "identity" : "feather-mail-ephemeral",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/feather-framework/feather-mail-ephemeral",
+      "state" : {
+        "revision" : "3420e21f505309f9820b9a8bec2fa0cc7ebc8aaa",
+        "version" : "1.0.0-beta.2"
+      }
+    },
+    {
+      "identity" : "postgres-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/postgres-nio.git",
+      "state" : {
+        "revision" : "f2188e05ba3546a76e61a5193c071b82c4d69a45",
+        "version" : "1.33.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-bcrypt",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/binarybirds/swift-bcrypt",
+      "state" : {
+        "revision" : "9e5387a4d9bac1c7227e366296c27b7612eba0b9",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/backend/app-modules/app-account-module/Package.swift
+++ b/backend/app-modules/app-account-module/Package.swift
@@ -1,0 +1,132 @@
+// swift-tools-version:6.1
+import PackageDescription
+
+// NOTE: https://github.com/swift-server/swift-http-server/blob/main/Package.swift
+var defaultSwiftSettings: [SwiftSetting] = [
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0441-formalize-language-mode-terminology.md
+    .swiftLanguageMode(.v6),
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+    .enableUpcomingFeature("MemberImportVisibility"),
+    // https://forums.swift.org/t/experimental-support-for-lifetime-dependencies-in-swift-6-2-and-beyond/78638
+    .enableExperimentalFeature("Lifetimes"),
+    .enableExperimentalFeature(
+        "AvailabilityMacro=AccountModule 1.0:macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0"
+    ),
+]
+
+#if compiler(>=6.2)
+defaultSwiftSettings.append(
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault")
+)
+#endif
+
+defaultSwiftSettings += [
+    .enableExperimentalFeature("StrictConcurrency=complete"),
+    .unsafeFlags(
+        ["-cross-module-optimization"],
+        .when(configuration: .release)
+    ),
+]
+
+let package = Package(
+    name: "app-account-module",
+    platforms: [
+        .macOS(.v15),
+        .iOS(.v18),
+        .tvOS(.v18),
+        .watchOS(.v11),
+        .visionOS(.v2),
+    ],
+    products: [
+        .library(name: "AccountDomain", targets: ["AccountDomain"]),
+        .library(name: "AccountApplication", targets: ["AccountApplication"]),
+        .library(name: "AccountInfrastructure", targets: ["AccountInfrastructure"]),
+    ],
+    dependencies: [
+        //        .package(
+        //            url: "https://github.com/apple/swift-log",
+        //            from: "1.0.0"
+        //        ),
+        //        .package(
+        //            url: "https://github.com/binarybirds/swift-nanoid",
+        //            from: "1.0.0"
+        //        ),
+
+        .package(
+            url: "https://github.com/binarybirds/swift-bcrypt",
+            from: "2.0.1"
+        ),
+        .package(
+            url: "https://github.com/apple/swift-nio",
+            from: "2.0.0"
+        ),
+        .package(
+            url: "https://github.com/feather-framework/feather-database",
+            exact: "1.0.0-beta.5"
+        ),
+        .package(
+            url: "https://github.com/feather-framework/feather-mail",
+            exact: "1.0.0-beta.3"
+        ),
+        .package(path: "../app-kernel"),
+
+        // MARK: - test dependencies
+
+        .package(
+            url: "https://github.com/feather-framework/feather-database-postgres",
+            exact: "1.0.0-beta.6"
+        ),
+        .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.32.2"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.34.0"),
+        .package(
+            url: "https://github.com/feather-framework/feather-mail-ephemeral",
+            exact: "1.0.0-beta.2"
+        ),
+    ],
+    targets: [
+        .target(
+            name: "AccountDomain",
+            dependencies: [.product(name: "Domain", package: "app-kernel")],
+            swiftSettings: defaultSwiftSettings
+        ),
+        .target(
+            name: "AccountApplication",
+            dependencies: [
+                .product(name: "Application", package: "app-kernel"),
+                .target(name: "AccountDomain"),
+            ],
+            swiftSettings: defaultSwiftSettings
+        ),
+        .target(
+            name: "AccountInfrastructure",
+            dependencies: [
+                .product(name: "Infrastructure", package: "app-kernel"),
+                .product(name: "FeatherDatabase", package: "feather-database"),
+                .product(name: "BCrypt", package: "swift-bcrypt"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .target(name: "AccountApplication"),
+            ],
+            swiftSettings: defaultSwiftSettings
+        ),
+        .testTarget(
+            name: "AccountDomainTests",
+            dependencies: [.target(name: "AccountDomain")],
+            swiftSettings: defaultSwiftSettings
+        ),
+        .testTarget(
+            name: "AccountApplicationTests",
+            dependencies: [.target(name: "AccountApplication")],
+            swiftSettings: defaultSwiftSettings
+        ),
+        .testTarget(
+            name: "AccountInfrastructureTests",
+            dependencies: [
+                .product(name: "FeatherDatabasePostgres", package: "feather-database-postgres"),
+                .product(name: "PostgresNIO", package: "postgres-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+                .target(name: "AccountInfrastructure"),
+            ],
+            swiftSettings: defaultSwiftSettings
+        ),
+    ]
+)

--- a/backend/app-modules/app-account-module/Sources/AccountApplication/Adapters/AccountSettings+DTOs.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountApplication/Adapters/AccountSettings+DTOs.swift
@@ -1,0 +1,1 @@
+// Placeholder for AccountSettings-to-DTO mappings.

--- a/backend/app-modules/app-account-module/Sources/AccountApplication/DTOs/AccountSettingsDetail.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountApplication/DTOs/AccountSettingsDetail.swift
@@ -1,0 +1,1 @@
+// Placeholder for the AccountSettingsDetail DTO.

--- a/backend/app-modules/app-account-module/Sources/AccountApplication/Permissions/AccountSettingsPermissions.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountApplication/Permissions/AccountSettingsPermissions.swift
@@ -1,0 +1,1 @@
+// Placeholder for AccountSettings permissions and ownership rules.

--- a/backend/app-modules/app-account-module/Sources/AccountApplication/Queries/AccountSettingsQueries.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountApplication/Queries/AccountSettingsQueries.swift
@@ -1,0 +1,1 @@
+// Placeholder for the AccountSettingsQueries application port.

--- a/backend/app-modules/app-account-module/Sources/AccountApplication/Scopes/ReadAccountSettings.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountApplication/Scopes/ReadAccountSettings.swift
@@ -1,0 +1,1 @@
+// Placeholder for the read AccountSettings scope.

--- a/backend/app-modules/app-account-module/Sources/AccountApplication/Scopes/WriteAccountSettings.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountApplication/Scopes/WriteAccountSettings.swift
@@ -1,0 +1,1 @@
+// Placeholder for the write AccountSettings scope.

--- a/backend/app-modules/app-account-module/Sources/AccountApplication/UseCases/Settings/EditAccountSettings.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountApplication/UseCases/Settings/EditAccountSettings.swift
@@ -1,0 +1,1 @@
+// Placeholder for the EditAccountSettings use-case.

--- a/backend/app-modules/app-account-module/Sources/AccountApplication/UseCases/Settings/GetAccountSettings.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountApplication/UseCases/Settings/GetAccountSettings.swift
@@ -1,0 +1,1 @@
+// Placeholder for the GetAccountSettings use-case.

--- a/backend/app-modules/app-account-module/Sources/AccountDomain/Models/AccountSettings.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountDomain/Models/AccountSettings.swift
@@ -1,0 +1,1 @@
+// Placeholder for the AccountSettings domain model.

--- a/backend/app-modules/app-account-module/Sources/AccountDomain/Repositories/AccountSettingsRepository.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountDomain/Repositories/AccountSettingsRepository.swift
@@ -1,0 +1,1 @@
+// Placeholder for the AccountSettingsRepository domain port.

--- a/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Database/AccessLayer/AccountSettingsTable.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Database/AccessLayer/AccountSettingsTable.swift
@@ -1,0 +1,1 @@
+// Placeholder for the account_settings access-layer table definition.

--- a/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Database/Migrations/TableMigration.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Database/Migrations/TableMigration.swift
@@ -1,0 +1,1 @@
+// Placeholder for Account module table migrations.

--- a/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Database/Migrations/TableSeedMigration.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Database/Migrations/TableSeedMigration.swift
@@ -1,0 +1,1 @@
+// Placeholder for Account module table seed migrations.

--- a/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Queries/DatabaseAccountSettingsQueries.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Queries/DatabaseAccountSettingsQueries.swift
@@ -1,0 +1,1 @@
+// Placeholder for the AccountSettings database query adapter.

--- a/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Repositories/DatabaseAccountSettingsRepository.swift
+++ b/backend/app-modules/app-account-module/Sources/AccountInfrastructure/Repositories/DatabaseAccountSettingsRepository.swift
@@ -1,0 +1,1 @@
+// Placeholder for the AccountSettings database repository adapter.

--- a/backend/app-modules/app-account-module/Tests/AccountApplicationTests/AccountApplicationTestSuite.swift
+++ b/backend/app-modules/app-account-module/Tests/AccountApplicationTests/AccountApplicationTestSuite.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import AccountApplication
+
+@Suite
+struct AccountApplicationTestSuite {
+
+    @Test
+    func moduleIsReadyForApplicationFeatures() {
+        // Placeholder
+    }
+}

--- a/backend/app-modules/app-account-module/Tests/AccountDomainTests/AccountDomainTestSuite.swift
+++ b/backend/app-modules/app-account-module/Tests/AccountDomainTests/AccountDomainTestSuite.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import AccountDomain
+
+@Suite
+struct AccountDomainTestSuite {
+
+    @Test
+    func moduleIsReadyForDomainFeatures() {
+        // _ = AccountSettings.self
+    }
+}

--- a/backend/app-modules/app-account-module/Tests/AccountInfrastructureTests/AccountInfrastructureTestSuite.swift
+++ b/backend/app-modules/app-account-module/Tests/AccountInfrastructureTests/AccountInfrastructureTestSuite.swift
@@ -1,0 +1,11 @@
+import Testing
+import AccountInfrastructure
+
+@Suite
+struct AccountInfrastructureTestSuite {
+
+    @Test
+    func moduleIsReadyForInfrastructureFeatures() {
+        // Placeholder
+    }
+}

--- a/backend/app-modules/app-account-module/docker-compose.yaml
+++ b/backend/app-modules/app-account-module/docker-compose.yaml
@@ -1,0 +1,65 @@
+services:
+    certificates:
+        build:
+            context: .
+            dockerfile: docker/certificates/Dockerfile
+        volumes:
+            - 'certificates:/certs'
+        restart: "no"
+
+    postgres:
+        build:
+            context: .
+            dockerfile: docker/postgres/Dockerfile
+        depends_on:
+            certificates:
+                condition: service_completed_successfully
+        volumes:
+            - 'certificates:/certs'
+            - 'postgres_data:/var/lib/postgresql'
+        ports:
+            - '55435:5432'
+        restart: always
+        environment:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: postgres
+        healthcheck:
+            test:
+                - CMD-SHELL
+                - |
+                    sh -c "pg_isready -d '
+                      host=127.0.0.1
+                      sslmode=verify-ca
+                      sslrootcert=/certs/ca.pem
+                      user=28830{POSTGRES_USER}
+                      password=28830{POSTGRES_PASSWORD}
+                      dbname=28830{POSTGRES_DB}
+                    '"
+            interval: 1s
+            timeout: 5s
+            retries: 10
+
+    tests:
+        build:
+            context: .
+            dockerfile: docker/tests/Dockerfile
+        depends_on:
+            postgres:
+                condition: service_healthy
+        environment:
+            POSTGRES_HOST: postgres
+            POSTGRES_PORT: "5432"
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: postgres
+        command:
+            - swift
+            - test
+            - --parallel
+
+volumes:
+    certificates:
+        name: app_account_module_certificates
+    postgres_data:
+        name: app_account_module_postgres_data

--- a/backend/app-modules/app-account-module/docker/certificates/Dockerfile
+++ b/backend/app-modules/app-account-module/docker/certificates/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache openssl
+
+COPY docker/certificates/scripts/generate-certificates.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/backend/app-modules/app-account-module/docker/certificates/scripts/generate-certificates.sh
+++ b/backend/app-modules/app-account-module/docker/certificates/scripts/generate-certificates.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+CERT_DIR="${CERT_DIR:-/certs}"
+mkdir -p "${CERT_DIR}"
+cd "${CERT_DIR}"
+
+if [ -f server.pem ] && [ -f server.key ] && [ -f ca.pem ]; then
+  exit 0
+fi
+
+openssl genpkey -algorithm RSA -out ca.key
+openssl req -new -x509 -key ca.key -out ca.pem -days 365 -subj "/CN=PostgreSQL-CA"
+openssl genpkey -algorithm RSA -out server.key
+openssl req -new -key server.key -out server.csr -subj "/CN=localhost"
+echo "subjectAltName=DNS:localhost,DNS:postgres,IP:127.0.0.1" > san.cnf
+openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out server.pem -days 365 -extfile san.cnf
+rm -f server.csr san.cnf ca.srl
+chown 999:999 server.key server.pem
+chmod 600 server.key
+chmod 644 server.pem ca.pem

--- a/backend/app-modules/app-account-module/docker/postgres/Dockerfile
+++ b/backend/app-modules/app-account-module/docker/postgres/Dockerfile
@@ -1,0 +1,6 @@
+FROM postgres:18.3
+
+WORKDIR /var/lib/postgresql
+
+COPY docker/postgres/scripts/config-ssl.sh /docker-entrypoint-initdb.d/
+RUN chmod +x /docker-entrypoint-initdb.d/config-ssl.sh

--- a/backend/app-modules/app-account-module/docker/postgres/scripts/config-ssl.sh
+++ b/backend/app-modules/app-account-module/docker/postgres/scripts/config-ssl.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+cat >>"$PGDATA/postgresql.conf" <<'EOF'
+ssl = on
+ssl_cert_file = '/certs/server.pem'
+ssl_key_file = '/certs/server.key'
+ssl_ca_file = '/certs/ca.pem'
+EOF
+
+cat >"$PGDATA/pg_hba.conf" <<'EOF'
+local all all trust
+hostssl all all 0.0.0.0/0 md5
+hostssl all all ::/0 md5
+EOF

--- a/backend/app-modules/app-account-module/docker/tests/Dockerfile
+++ b/backend/app-modules/app-account-module/docker/tests/Dockerfile
@@ -1,0 +1,10 @@
+FROM swift:6.1
+
+WORKDIR /app
+
+COPY . ./
+
+RUN swift package resolve
+RUN swift package clean
+
+CMD ["swift", "test", "--parallel"]


### PR DESCRIPTION
Introduce a new app-account-module (AccountDomain, AccountApplication, AccountInfrastructure) with Package.swift, Makefile, tests, docker compose/Dockerfiles and placeholder source files (models, DTOs, queries, use-cases, migrations, repositories). Wire the module into the backend by updating backend/Package.swift and adding AccountModule builder (AppModules import and initialization) so the server runtime includes the account module. Placeholders provided for future implementation; CI/test scaffolding and DB SSL/docker helpers included.